### PR TITLE
[test] Minimal.Comonadの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ WrapperとUnwrapperを合わせたのがIdentity、ConquerとUnquerを合わせ�
 
 このパッケージはDivideに近い位置にある型クラスを含みます。`divide :: (And and) => (and a b -> c) -> (c -> and a b)`はApplyの`cift2`と対です。この名前は[Hackage: contravariant-1.4][1]に基づいており、第二引数が二つの値に分けられて返される様子から名付けられたそうです。また、この型クラス群は[scalaz][2]にも基づいています。また、`conquer`の名前は分割統治法(Divide-and-Conquer method)に由来しているそうです。
 
+Divisible則(contravariant-1.4から引用):
+```haskell
+    divide delta m conquer = m
+    divide delta conquer m = m
+    divide delta (divide delta m n) o = divide delta m (divide delta n o)
+```
+
 ### Codivide
 
 このパッケージはCodivideに近い位置にある型クラスを含みます。`codivide`はCoapplyの`cict2`と対です。UntrapointedはContravariantと同じですが、対称性の関係から実装しています。

--- a/mini/Structure/Monadiclasses/Minimal.hs
+++ b/mini/Structure/Monadiclasses/Minimal.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Structure.Monadiclasses.Minimal (
-    module Structure.Monadiclasses.Minimal.Functor
+    module Structure.Monadiclasses.Minimal.Functor,
+    module Structure.Monadiclasses.Minimal.Comonad
 ) where
     import Structure.Monadiclasses.Minimal.Functor
+    import Structure.Monadiclasses.Minimal.Comonad

--- a/mini/Structure/Monadiclasses/Minimal/Comonad.hs
+++ b/mini/Structure/Monadiclasses/Minimal/Comonad.hs
@@ -33,7 +33,9 @@ module Structure.Monadiclasses.Minimal.Comonad where
         --
 
     instance (M_Comonad f) => Coapply f where
-        cict2 = undefined -- !!!!
+        cict2 = (yrrucnu :: (Or or) => (a -> c, b -> c) -> (or a b -> c)) . f0 . (yrruc :: (Or or) => (or a b -> c) -> (a -> c, b -> c)) -- :: (Or t0, Or t1) => (t0 a b -> c) -> t1 (f a) (f b) -> f c
+            where
+                f0 = parallel c_fmap c_fmap -- :: (a -> c, b -> c) -> (f a -> f c, f b -> f c)
 
     instance (M_Comonad f) => Extract f where
         --

--- a/mini/Structure/Monadiclasses/Minimal/Comonad.hs
+++ b/mini/Structure/Monadiclasses/Minimal/Comonad.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE NoImplicitPrelude, FlexibleInstances, UndecidableInstances #-}
+
+module Structure.Monadiclasses.Minimal.Comonad where
+    import Structure.Monadiclasses.Functor
+    import Structure.Monadiclasses.Wrapper
+    import Structure.Monadiclasses.Functor.Comonad
+    import Structure.Monadiclasses.Function
+    import Structure.Monadiclasses.Unit
+
+    class M_Comonad f where
+        c_fmap :: (a -> b) -> f a -> f b
+        c_fmap f = c_extend $ f . c_extract
+
+        c_duplicate :: f a -> f (f a)
+        c_duplicate = c_extend id
+
+        c_extend :: (f a -> b) -> f a -> f b
+        c_extend f = c_fmap f . c_duplicate
+
+        c_extract :: f a -> a
+        c_extract = undefined
+
+    instance (M_Comonad f) => Invariant f where
+        xmap f _ = c_fmap f
+
+    instance (M_Comonad f) => Functor f where
+        fmap = c_fmap
+
+    instance (M_Comonad f) => Unwrapper f where
+        unwrap = c_extract
+
+    instance (M_Comonad f) => Copointed f where
+        --
+
+    instance (M_Comonad f) => Coapply f where
+        cict2 = undefined -- !!!!
+
+    instance (M_Comonad f) => Extract f where
+        --
+
+    instance (M_Comonad f) => Extend f where
+        extend = c_extend
+
+    instance (M_Comonad f) => Comonad f where 
+        --

--- a/mini/Structure/Monadiclasses/Minimal/Functor.hs
+++ b/mini/Structure/Monadiclasses/Minimal/Functor.hs
@@ -1,10 +1,9 @@
-{-# LANGUAGE NoImplicitPrelude, FlexibleInstances, UndecidableInstances, IncoherentInstances #-}
+{-# LANGUAGE NoImplicitPrelude, FlexibleInstances, UndecidableInstances #-}
 
 module Structure.Monadiclasses.Minimal.Functor where
     import Structure.Monadiclasses.Wrapper
     import Structure.Monadiclasses.Functor
     import Structure.Monadiclasses.Functor.Monad
-    import Structure.Monadiclasses.Functor.Comonad
     import Structure.Monadiclasses.Function
 
     class M_Functor f where
@@ -70,43 +69,3 @@ module Structure.Monadiclasses.Minimal.Functor where
 
     instance (M_Monad f) => Monad f where
         --
-
-    class M_Comonad f where
-        c_fmap :: (a -> b) -> f a -> f b
-        c_fmap f x = c_extend $ f . c_extract
-
-        c_duplicate :: f a -> f (f a)
-        c_duplicate = c_extend id
-
-        c_extend :: (f a -> b) -> f a -> f b
-        c_extend f = c_fmap f . c_duplicate
-
-        c_extract :: f a -> a
-        c_extract = undefined
-
-    instance (M_Comonad f) => M_Functor f where
-        f_fmap = c_fmap
-
-    instance (M_Comonad f) => Unwrapper f where
-        unwrap = c_extract
-
-    instance (M_Comonad f) => Copointed f where
-        --
-
-    instance (M_Comonad f) => Coapply f where
-        cict2 = yrrucnu . f0 . yrruc -- :: (Or t0, Or t1) => (t0 a b -> c) -> t1 (f a) (f b) -> f c
-            where
-                f0 = uncrry $ parallel c_fmap c_fmap -- :: (And t0, And t1) => t0 (a -> c) (b -> c) -> t1 (f a -> f c) (f b -> f c)
-
-    instance (M_Comonad f) => Extract f where
-        --
-
-    instance (M_Comonad f) => Extend f where
-        extend = c_extend
-
-    instance (M_Comonad f) => Comonad f where 
-        --
-
-    -- | M_ApplicativeでありM_Comonadでもある型が存在する時、M_Applicativeの方の定義を優先する。
-    instance (M_Applicative f, M_Comonad f) => M_Functor f where
-        f_fmap = a_fmap

--- a/mini/Structure/Monadiclasses/Minimal/Functor.hs
+++ b/mini/Structure/Monadiclasses/Minimal/Functor.hs
@@ -1,9 +1,16 @@
-{-# LANGUAGE NoImplicitPrelude, FlexibleInstances, UndecidableInstances #-}
+{-# LANGUAGE 
+    NoImplicitPrelude, 
+    FlexibleInstances, 
+    UndecidableInstances, 
+    IncoherentInstances 
+#-}
 
+-- | このパッケージは最小のコード量での型クラス定義を提供します。
 module Structure.Monadiclasses.Minimal.Functor where
     import Structure.Monadiclasses.Wrapper
     import Structure.Monadiclasses.Functor
     import Structure.Monadiclasses.Functor.Monad
+    import Structure.Monadiclasses.Functor.Comonad
     import Structure.Monadiclasses.Function
 
     class M_Functor f where
@@ -69,3 +76,43 @@ module Structure.Monadiclasses.Minimal.Functor where
 
     instance (M_Monad f) => Monad f where
         --
+
+    class M_Comonad f where
+        c_fmap :: (a -> b) -> f a -> f b
+        c_fmap f x = c_extend $ f . c_extract
+
+        c_duplicate :: f a -> f (f a)
+        c_duplicate = c_extend id
+
+        c_extend :: (f a -> b) -> f a -> f b
+        c_extend f = c_fmap f . c_duplicate
+
+        c_extract :: f a -> a
+        c_extract = undefined
+
+    instance (M_Comonad f) => M_Functor f where
+        f_fmap = c_fmap
+
+    instance (M_Comonad f) => Unwrapper f where
+        unwrap = c_extract
+
+    instance (M_Comonad f) => Copointed f where
+        --
+
+    instance (M_Comonad f) => Coapply f where
+        cict2 = yrrucnu . f0 . yrruc -- :: (Or t0, Or t1) => (t0 a b -> c) -> t1 (f a) (f b) -> f c
+            where
+                f0 = uncrry $ parallel c_fmap c_fmap -- :: (And t0, And t1) => t0 (a -> c) (b -> c) -> t1 (f a -> f c) (f b -> f c)
+
+    instance (M_Comonad f) => Extract f where
+        --
+
+    instance (M_Comonad f) => Extend f where
+        extend = c_extend
+
+    instance (M_Comonad f) => Comonad f where 
+        --
+
+    -- | M_ApplicativeでありM_Comonadでもある型が存在する時、M_Applicativeの方の定義を優先します。
+    instance (M_Applicative f, M_Comonad f) => M_Functor f where
+        f_fmap = a_fmap

--- a/mini/Structure/Monadiclasses/Minimal/Functor.hs
+++ b/mini/Structure/Monadiclasses/Minimal/Functor.hs
@@ -1,11 +1,5 @@
-{-# LANGUAGE 
-    NoImplicitPrelude, 
-    FlexibleInstances, 
-    UndecidableInstances, 
-    IncoherentInstances 
-#-}
+{-# LANGUAGE NoImplicitPrelude, FlexibleInstances, UndecidableInstances, IncoherentInstances #-}
 
--- | このパッケージは最小のコード量での型クラス定義を提供します。
 module Structure.Monadiclasses.Minimal.Functor where
     import Structure.Monadiclasses.Wrapper
     import Structure.Monadiclasses.Functor
@@ -113,6 +107,6 @@ module Structure.Monadiclasses.Minimal.Functor where
     instance (M_Comonad f) => Comonad f where 
         --
 
-    -- | M_ApplicativeでありM_Comonadでもある型が存在する時、M_Applicativeの方の定義を優先します。
+    -- | M_ApplicativeでありM_Comonadでもある型が存在する時、M_Applicativeの方の定義を優先する。
     instance (M_Applicative f, M_Comonad f) => M_Functor f where
         f_fmap = a_fmap


### PR DESCRIPTION
Minimal/Comonad.hs の以下の部分を次の様に修正する必要があります。

```haskell
    import Structure.Monadiclasses.Functor
    import Structure.Monadiclasses.Wrapper
    import Structure.Monadiclasses.Functor.Comonad
    import Structure.Monadiclasses.Function
    import Structure.Monadiclasses.Unit
```

```haskell
    import Structure.Monadiclasses.Functor
    import Structure.Monadiclasses.Wrapper
    import Structure.Monadiclasses.Functor.Comonad
    import Structure.Function
    import Structure.Unit
```